### PR TITLE
Add Haml 'support'

### DIFF
--- a/lib/hologram_markdown_renderer.rb
+++ b/lib/hologram_markdown_renderer.rb
@@ -32,7 +32,7 @@ class HologramMarkdownRenderer < Redcarpet::Render::HTML
         '<script>' + code + '</script>
         <div class="codeBlock jsExample">' + Pygments.highlight(code) + '</div>'
       else
-        '<div class="codeExample">' + '<div class="exampleOutput">' + render_html(code, language) + '</div>' + '<div class="codeBlock">' + Pygments.highlight(code) + '</div>' + '</div>'
+        '<div class="codeExample">' + '<div class="exampleOutput">' + render_html(code, language) + '</div>' + '<div class="codeBlock">' + Pygments.highlight(code, lexer: get_lexer(language)) + '</div>' + '</div>'
       end
     else
       '<div class="codeBlock">' + Pygments.highlight(code) + '</div>'
@@ -41,13 +41,21 @@ class HologramMarkdownRenderer < Redcarpet::Render::HTML
 
   private
   def render_html(code, language)
-
     case language
       when 'haml_example'
         safe_require 'haml', language
         return Haml::Engine.new(code.strip).render(Object.new, {})
       else
         code
+    end
+  end
+
+  def get_lexer(language)
+    case language
+      when 'haml_example'
+        'haml'
+      else
+        'html'
     end
   end
 


### PR DESCRIPTION
- If Haml is available and the user specifies 'haml_example' in the code
  block, convert haml to html for display purposes but render a haml
  example.
