### PR TITLE
Refactor, extract parser from builder

### DIFF
--- a/lib/hologram.rb
+++ b/lib/hologram.rb
@@ -119,31 +119,10 @@ module Hologram
         DisplayMessage.warning("Could not find documentation assets at #{config['documentation_assets']}")
       end
 
-      # recursively traverse our directory structure looking for files that
-      # match our "parseable" file types. Open those files pulling out any
-      # comments matching the hologram doc style /*doc */ and create DocBlock
-      # objects from those comments, then add those to a collection object which
-      # is then returned.
-      doc_block_collection = process_dir(input_directory)
+      @pages = DocParser.new(input_directory, config['index']).parse
 
-      # doc blocks can define parent/child relationships that will nest their
-      # documentation appropriately. we can't put everything into that structure
-      # on our first pass through because there is no guarantee we'll parse files
-      # in the correct order. This step takes the full collection and creates the
-      # proper structure.
-      doc_block_collection.create_nested_structure
-
-      # hand off our properly nested collection to the output generator
-      build_pages_from_doc_blocks(doc_block_collection.doc_blocks)
-
-      # if we have an index category defined in our config copy that
-      # page to index.html
-      if config['index']
-        if @pages.has_key?(config['index'] + '.html')
-          @pages['index.html'] = @pages[config['index'] + '.html']
-        else
-          DisplayMessage.warning("Could not generate index.html, there was no content generated for the category #{config['index']}.")
-        end
+      if config['index'] && !@pages.has_key?(config['index'] + '.html')
+        DisplayMessage.warning("Could not generate index.html, there was no content generated for the category #{config['index']}.")
       end
 
       write_docs(output_directory, doc_assets)
@@ -170,78 +149,6 @@ module Hologram
          next if item == '.' or item == '..' or item.start_with?('_')
          `rm -rf #{output_directory}/#{item}`
          `cp -R #{doc_assets}/#{item} #{output_directory}/#{item}`
-        end
-      end
-    end
-
-
-    def process_dir(base_directory)
-      #get all directories in our library folder
-      doc_block_collection = DocBlockCollection.new
-      directories = Dir.glob("#{base_directory}/**/*/")
-      directories.unshift(base_directory)
-
-      directories.each do |directory|
-        # filter and sort the files in our directory
-        files = []
-        Dir.foreach(directory).select{ |file| is_supported_file_type?(file) }.each do |file|
-          files << file
-        end
-        files.sort!
-        process_files(files, directory, doc_block_collection)
-      end
-      doc_block_collection
-    end
-
-
-    def process_files(files, directory, doc_block_collection)
-      files.each do |input_file|
-        if input_file.end_with?('md')
-          @pages[File.basename(input_file, '.md') + '.html'] = {:md => File.read("#{directory}/#{input_file}"), :blocks => []}
-        else
-          process_file("#{directory}/#{input_file}", doc_block_collection)
-        end
-      end
-    end
-
-
-    def process_file(file, doc_block_collection)
-      file_str = File.read(file)
-      # get any comment blocks that match the patterns:
-      # .sass: //doc (follow by other lines proceeded by a space)
-      # other types: /*doc ... */
-      if file.end_with?('.sass')
-        hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/)
-      else
-        hologram_comments = file_str.scan(/^\s*\/\*doc(.*?)\*\//m)
-      end
-      return unless hologram_comments
-
-      hologram_comments.each do |comment_block|
-        doc_block_collection.add_doc_block(comment_block[0])
-      end
-    end
-
-
-    def build_pages_from_doc_blocks(doc_blocks, output_file = nil, depth = 1)
-      doc_blocks.sort.map do |key, doc_block|
-
-        # if the doc_block has a category set then use that, this will be
-        # true of all top level doc_blocks. The output file they set will then
-        # be passed into the recursive call for adding children to the output
-        output_file = get_file_name(doc_block.category) if doc_block.category
-
-        if !@pages.has_key?(output_file)
-          @pages[output_file] = {:md => "", :blocks => []}
-        end
-
-        @pages[output_file][:blocks].push(doc_block.get_hash)
-        @pages[output_file][:md] << doc_block.markdown_with_heading(depth)
-
-        if doc_block.children
-          depth += 1
-          build_pages_from_doc_blocks(doc_block.children, output_file, depth)
-          depth -= 1
         end
       end
     end
@@ -333,11 +240,6 @@ module Hologram
     end
 
 
-    def is_supported_file_type?(file)
-      @supported_extensions.include?(File.extname(file))
-    end
-
-
     def get_file_name(str)
       str = str.gsub(' ', '_').downcase + '.html'
     end
@@ -345,6 +247,126 @@ module Hologram
 
     def get_fh(output_directory, output_file)
       File.open("#{output_directory}/#{output_file}", 'w')
+    end
+  end
+
+
+ class DocParser
+    SUPPORTED_EXTENSIONS = ['.css', '.scss', '.less', '.sass', '.styl', '.js', '.md', '.markdown' ]
+    attr_accessor :source_path, :pages, :doc_blocks
+
+    def initialize(source_path, index_name = nil)
+      @source_path = source_path
+      @index_name = index_name
+      @pages = {}
+    end
+
+    def parse
+      # recursively traverse our directory structure looking for files that
+      # match our "parseable" file types. Open those files pulling out any
+      # comments matching the hologram doc style /*doc */ and create DocBlock
+      # objects from those comments, then add those to a collection object which
+      # is then returned.
+      doc_block_collection = process_dir(source_path)
+
+      # doc blocks can define parent/child relationships that will nest their
+      # documentation appropriately. we can't put everything into that structure
+      # on our first pass through because there is no guarantee we'll parse files
+      # in the correct order. This step takes the full collection and creates the
+      # proper structure.
+      doc_block_collection.create_nested_structure
+
+      # hand off our properly nested collection to the output generator
+      build_pages_from_doc_blocks(doc_block_collection.doc_blocks)
+
+      # if we have an index category defined in our config copy that
+      # page to index.html
+      if @index_name
+        name = @index_name + '.html'
+        if @pages.has_key?(name)
+          @pages['index.html'] = @pages[name]
+        end
+      end
+
+      pages
+    end
+
+    private
+
+    def process_dir(base_directory)
+      #get all directories in our library folder
+      doc_block_collection = DocBlockCollection.new
+      directories = Dir.glob("#{base_directory}/**/*/")
+      directories.unshift(base_directory)
+
+      directories.each do |directory|
+        # filter and sort the files in our directory
+        files = []
+        Dir.foreach(directory).select{ |file| is_supported_file_type?(file) }.each do |file|
+          files << file
+        end
+        files.sort!
+        process_files(files, directory, doc_block_collection)
+      end
+      doc_block_collection
+    end
+
+    def process_files(files, directory, doc_block_collection)
+      files.each do |input_file|
+        if input_file.end_with?('md')
+          @pages[File.basename(input_file, '.md') + '.html'] = {:md => File.read("#{directory}/#{input_file}"), :blocks => []}
+        else
+          process_file("#{directory}/#{input_file}", doc_block_collection)
+        end
+      end
+    end
+
+    def process_file(file, doc_block_collection)
+      file_str = File.read(file)
+      # get any comment blocks that match the patterns:
+      # .sass: //doc (follow by other lines proceeded by a space)
+      # other types: /*doc ... */
+      if file.end_with?('.sass')
+        hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/)
+      else
+        hologram_comments = file_str.scan(/^\s*\/\*doc(.*?)\*\//m)
+      end
+      return unless hologram_comments
+
+      hologram_comments.each do |comment_block|
+        doc_block_collection.add_doc_block(comment_block[0])
+      end
+    end
+
+    def build_pages_from_doc_blocks(doc_blocks, output_file = nil, depth = 1)
+      doc_blocks.sort.map do |key, doc_block|
+
+        # if the doc_block has a category set then use that, this will be
+        # true of all top level doc_blocks. The output file they set will then
+        # be passed into the recursive call for adding children to the output
+        output_file = get_file_name(doc_block.category) if doc_block.category
+
+        if !@pages.has_key?(output_file)
+          @pages[output_file] = {:md => "", :blocks => []}
+        end
+
+        @pages[output_file][:blocks].push(doc_block.get_hash)
+        @pages[output_file][:md] << doc_block.markdown_with_heading(depth)
+
+        if doc_block.children
+          depth += 1
+          build_pages_from_doc_blocks(doc_block.children, output_file, depth)
+          depth -= 1
+        end
+      end
+    end
+
+    def is_supported_file_type?(file)
+      SUPPORTED_EXTENSIONS.include?(File.extname(file))
+    end
+
+    def get_file_name(str)
+      str = str.gsub(' ', '_').downcase + '.html'
     end
   end
 

--- a/spec/doc_parser_spec.rb
+++ b/spec/doc_parser_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe Hologram::DocParser do
+
+  let(:doc) do
+<<-eos
+/*doc
+---
+title: Some other style
+name: otherStyle
+category: Foo
+---
+Markdown stuff
+*/
+eos
+  end
+
+  let(:child_doc) do
+<<-eos
+/*doc
+---
+parent: button
+name: otherStyle
+title: Some other style
+---
+Markdown stuff
+*/
+eos
+  end
+
+  let(:source_path) { 'spec/fixtures/source' }
+  let(:temp_doc) { File.join(source_path, 'components', 'button', 'skin', 'testSkin.css') }
+
+  subject(:parser) { Hologram::DocParser.new('spec/fixtures/source') }
+
+  context '#parse' do
+    let(:result) { parser.parse }
+
+    it 'builds and returns a hash of pages' do
+      expect(result).to be_a Hash
+    end
+
+    context 'when an index page is specified' do
+      subject(:parser) { Hologram::DocParser.new('spec/fixtures/source', 'foo') }
+
+      around do |example|
+        File.open(temp_doc, 'a+'){ |io| io << doc }
+        example.run
+        FileUtils.rm(temp_doc)
+      end
+
+      it 'uses that page as the index' do
+        expect(result['index.html'][:md]).to include 'Markdown stuff'
+      end
+    end
+
+    context 'when the source is a parent doc' do
+      around do |example|
+        File.open(temp_doc, 'a+'){ |io| io << doc }
+        example.run
+        FileUtils.rm(temp_doc)
+      end
+
+      it 'takes the category in a collection and treats them as the page names' do
+        expect(result.keys).to include 'foo.html'
+      end
+    end
+
+    context 'when a source doc is a child' do
+      around do |example|
+        File.open(temp_doc, 'a+'){ |io| io << child_doc }
+        example.run
+        FileUtils.rm(temp_doc)
+      end
+
+      before do
+        parser.parse
+      end
+
+      it 'appends the child doc to the category page' do
+        expect(result['base_css.html'][:md]).to include 'Some other style'
+      end
+
+      it 'assigns the child doc a deeper header' do
+        expect(result['base_css.html'][:md]).to include '<h2 id="otherStyle">Some other style</h2>'
+      end
+    end
+  end
+end


### PR DESCRIPTION
I have a scenario where i would like to use hologram without building the docs immediately. So I extracted all the parsing methods into a class of its own and contained the system exits in the doc builder. 

The refactor is super light, just moved the methods around. But it sure is easier to test. :)

Thoughts or suggestions?
