### PR TITLE
Allow users to specify ruby dependencies

### DIFF
--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -52,6 +52,13 @@ module Hologram
 
     private
     def build_docs
+      # Read and require the Ruby dependencies
+      if config['ruby_dependencies']
+        config['ruby_dependencies'].each do |file|
+          require file
+        end
+      end
+
       # Create the output directory if it doesn't exist
       FileUtils.mkdir_p(config['destination']) unless File.directory?(config['destination'])
 

--- a/lib/hologram_markdown_renderer.rb
+++ b/lib/hologram_markdown_renderer.rb
@@ -18,7 +18,8 @@ class HologramMarkdownRenderer < Redcarpet::Render::HTML
     case language
       when 'haml_example'
         safe_require('haml', language)
-        return Haml::Engine.new(code.strip).render(Object.new, {})
+        scope = defined?(HologramViewScope) ? HologramViewScope.new : Object.new
+        return Haml::Engine.new(code.strip).render(scope, {})
       else
         code
     end


### PR DESCRIPTION
- HologramViewScope can be defined as a ruby dependency allowing the
  user to define a scope object for rendering Haml. Allows for the use
  of ruby helper functions.
- ruby dependencies can be specified under 'ruby_dependencies' in the hologram_config.yml
