### PR TITLE
Add a template rendering scope method in hologram_markdown_renderer

### DIFF
--- a/lib/hologram_markdown_renderer.rb
+++ b/lib/hologram_markdown_renderer.rb
@@ -18,10 +18,14 @@ class HologramMarkdownRenderer < Redcarpet::Render::HTML
     case language
       when 'haml_example'
         safe_require('haml', language)
-        return Haml::Engine.new(code.strip).render(Object.new, {})
+        return Haml::Engine.new(code.strip).render(template_rendering_scope, {})
       else
         code
     end
+  end
+
+  def template_rendering_scope
+    Object.new
   end
 
   def get_lexer(language)


### PR DESCRIPTION
- This allows for the ability to define a haml rendering scope when
  using the 'custom_markdown_renderer' option in hologram_config.yml.
  We no longer need to rewrite the entire render_html method when
  defining a custom_markdown_renderer.
