### PR TITLE
Refactor doc collection, block, and add custom error

### DIFF
--- a/lib/hologram.rb
+++ b/lib/hologram.rb
@@ -12,6 +12,7 @@ require 'hologram/doc_parser'
 require 'hologram/doc_builder'
 require 'hologram/template_variables'
 require 'hologram/display_message'
+require 'hologram/errors'
 
 require 'hologram_markdown_renderer'
 

--- a/lib/hologram/doc_block_collection.rb
+++ b/lib/hologram/doc_block_collection.rb
@@ -8,24 +8,11 @@ module Hologram
 
     # this should throw an error if we have a match, but no yaml_match
     def add_doc_block(comment_block)
-      yaml_match = /^\s*---\s(.*?)\s---$/m.match(comment_block)
-      return unless yaml_match
+      doc_block = DocumentBlock.from_comment(comment_block)
+      return unless doc_block
+      skip_block and return if !doc_block.is_valid?
 
-      markdown = comment_block.sub(yaml_match[0], '')
-
-      begin
-        config = YAML::load(yaml_match[1])
-      rescue
-        DisplayMessage.error("Could not parse YAML:\n#{yaml_match[1]}")
-      end
-
-      if config['name'].nil?
-        DisplayMessage.warning("Missing required name config value. This hologram comment will be skipped. \n #{config.inspect}")
-      else
-        doc_block = DocumentBlock.new(config, markdown)
-      end
-
-      @doc_blocks[doc_block.name] = doc_block if doc_block.is_valid?
+      @doc_blocks[doc_block.name] = doc_block
     end
 
     def create_nested_structure
@@ -43,6 +30,12 @@ module Hologram
       blocks_to_remove_from_top_level.each do |key|
         @doc_blocks.delete(key)
       end
+    end
+
+    private
+
+    def skip_block
+      DisplayMessage.warning(doc_block.errors.join("\n") << "This hologram comment will be skipped.")
     end
   end
 end

--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -68,8 +68,12 @@ module Hologram
         DisplayMessage.warning("Could not find documentation assets at #{config['documentation_assets']}")
       end
 
-      doc_parser = DocParser.new(input_directory, config['index'])
-      @pages, @categories = doc_parser.parse
+      begin
+        doc_parser = DocParser.new(input_directory, config['index'])
+        @pages, @categories = doc_parser.parse
+      rescue CommentLoadError => e
+        DisplayMessage.error(e.message)
+      end
 
       if config['index'] && !@pages.has_key?(config['index'] + '.html')
         DisplayMessage.warning("Could not generate index.html, there was no content generated for the category #{config['index']}.")

--- a/lib/hologram/errors.rb
+++ b/lib/hologram/errors.rb
@@ -1,0 +1,4 @@
+module Hologram
+  class CommentLoadError < StandardError
+  end
+end


### PR DESCRIPTION
Hi all,
I've moved some of the comment block parsing responsibilities from the DocBlockCollection to the DocumentBlock. It made things a bit cleaner. 

Additional I added an error class, and rescued inside the DocBuilder. This is because Display.error was being called inside the DocCollection, so there was a possibility of it system exiting if i used that class on its own.

Any feedback would be appreciated.
J
