### PR TITLE
Remove error squashing

### DIFF
--- a/lib/hologram/cli.rb
+++ b/lib/hologram/cli.rb
@@ -37,6 +37,8 @@ module Hologram
       builder = DocBuilder.from_yaml(config)
       DisplayMessage.error(builder.errors.first) if !builder.is_valid?
       builder.build
+    rescue CommenLoadError => e
+      DisplayMessage.error(e.message)
     rescue Errno::ENOENT
       DisplayMessage.error("Could not load config file, try 'hologram init' to get started")
     end


### PR DESCRIPTION
@jho406 - I think we might be hurting ourselves by cleaning up all error messages that we don't explicitly handle. Users won't be able to give us a full stack trace when something goes wrong. 

Does this change look reasonable?

Thanks!
