### PR TITLE
Test against latest ruby 2.1 point release instead of 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ script: "bundle exec rake spec"
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.0
+  - 2.1
   - rbx
 
 notifications:


### PR DESCRIPTION
This should get our tests back in the green. We might want to add 2.1.0 again later when/if https://github.com/travis-ci/travis-ci/issues/2220 is resolved.
