### PR TITLE
Use UTF-8 as default encoding

### DIFF
--- a/lib/hologram.rb
+++ b/lib/hologram.rb
@@ -16,6 +16,9 @@ require 'hologram/errors'
 require 'hologram/utils'
 require 'hologram/markdown_renderer'
 
+Encoding.default_internal = Encoding::UTF_8
+Encoding.default_external = Encoding::UTF_8
+
 module Hologram
   INIT_TEMPLATE_PATH = File.expand_path('./template/', File.dirname(__FILE__)) + '/'
   INIT_TEMPLATE_FILES = [


### PR DESCRIPTION
This fixes https://github.com/trulia/hologram/issues/79 but I think we might need a different solution. Should we be able to define an encoding in the config file (but default to UTF-8?) 
