### PR TITLE
Ease dependency versions

### DIFF
--- a/hologram.gemspec
+++ b/hologram.gemspec
@@ -13,8 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://trulia.github.io/hologram"
   spec.license       = "MIT"
 
-  spec.add_dependency "redcarpet", "~> 2.2.2"
-  spec.add_dependency "pygments.rb", "~> 0.4.2"
+  spec.add_dependency "redcarpet", "~> 2.2"
+  spec.add_dependency "pygments.rb", "~> 0.4"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = ['hologram']
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 2.14.1"
+  spec.add_development_dependency "rspec", "~> 2.14"
 end


### PR DESCRIPTION
Hologram seems to work with current latest minor releases. Any opinions on if we should use "~> 0.4" or just bump to the latest minor release?
