### PR TITLE
Updated README.md to address concern in Issue 105.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ This will create a `hologram_config.yml` file  (more on this below), and
 also create a starter `_header.html` and `_footer.html` file for you.
 You can then tweak the config values and start documenting your css.
 
+Add some documentation to one of your stylesheets:
+
+    /*doc
+    ---
+    title: Alert
+    name: alert
+    category: basics
+    ---
+    ```html_example
+        <div class='alert'>Hello</div>
+    ```
+    */
+
 Building the documentation is simply:
 
 ``` hologram ```


### PR DESCRIPTION
https://github.com/trulia/hologram/issues/105

The Quick Start skips an important step. Without this step, new users will see an error which is confusing for someone evaluating the tool.

Warning: Could not generate index.html, there was no content generated for the category basics.
