### PR TITLE
Classname Clicker plugin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ The following preprocessors/file types are supported by Hologram:
 - [Grunt Hologram](https://github.com/jchild3rs/grunt-hologram/) is a sweet
   little grunt task that will generate your hologram style guide.
 
+- [Classname Clicker](https://github.com/bigethan/hologram-addons/) is a handy
+UI addition that gives the ability to see rules that apply to a classname by 
+clicking on them within hologram.
+
 
 ## Contributing
 


### PR DESCRIPTION
Linking to the classname clicker plugin in the readme.
