### PR TITLE
Remove --root command line flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,6 @@ Hologram has a couple of command line flags:
 
 * `-c` or `--config` - specify the config file, by default hologram
   looks for `hologram_config.yml`
-* `-r` or `--root` - specify the directory to use when processing files
-  (useful if you run hologram in a different directory than your assets.
-  Defaults to current working directory)
 
 ## Details
 


### PR DESCRIPTION
According to the discussions on #118, removing the `--root` command line flag from the documentation. See also: commit ea32e9abbca15ad89b3b2e8f5619fa665723e874.

Shall I also change...

> Hologram has a couple of command line flags:

... to...

> Hologram has a command line flag:

?
