### PR TITLE
Add support for multiple source directories to the hologram config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ hologram path/to/your/config.yml`
 
 Your config file needs to contain the following key/value pairs
 
-* **source**: relative path to your source files
+* **source**: relative path(s) to your source files. Accepts either a
+  single value or an array
 
 * **destination**: relative path where you want the documentation to be
   built
@@ -136,6 +137,11 @@ Your config file needs to contain the following key/value pairs
 
     # The directory containing the source files to parse recursively
     source: ./sass
+
+    # You may alternately specify multiple directories.
+    # source:
+    #  - ./sass
+    #  - ./library-sass
 
     # The directory that hologram will build to
     destination: ./docs
@@ -307,6 +313,8 @@ These fine people have also contributed to making hologram a better gem:
 * [Dominick Reinhold](https://github.com/d-reinhold)
 * [Nicole Sullivan](https://github.com/stubbornella)
 * [Mike Wilkes](https://github.com/mikezx6r)
+* [Vanessa Sant'Anna](https://github.com/vsanta)
+* [Geoffrey Giesemann](https://github.com/geoffwa)
 
 
 ## License

--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -4,7 +4,7 @@ module Hologram
     attr_accessor :source_path, :pages, :doc_blocks
 
     def initialize(source_path, index_name = nil)
-      @source_path = source_path
+      @source_paths = Array(source_path)
       @index_name = index_name
       @pages = {}
       @output_files_by_category = {}
@@ -16,7 +16,12 @@ module Hologram
       # comments matching the hologram doc style /*doc */ and create DocBlock
       # objects from those comments, then add those to a collection object which
       # is then returned.
-      doc_block_collection = process_dir(source_path)
+
+      doc_block_collection = DocBlockCollection.new
+
+      @source_paths.each do |source_path|
+        process_dir(source_path, doc_block_collection)
+      end
 
       # doc blocks can define parent/child relationships that will nest their
       # documentation appropriately. we can't put everything into that structure
@@ -43,9 +48,8 @@ module Hologram
 
     private
 
-    def process_dir(base_directory)
+    def process_dir(base_directory, doc_block_collection)
       #get all directories in our library folder
-      doc_block_collection = DocBlockCollection.new
       directories = Dir.glob("#{base_directory}/**/*/")
       directories.unshift(base_directory)
 
@@ -58,7 +62,6 @@ module Hologram
         files.sort!
         process_files(files, directory, doc_block_collection)
       end
-      doc_block_collection
     end
 
     def process_files(files, directory, doc_block_collection)

--- a/spec/doc_parser_spec.rb
+++ b/spec/doc_parser_spec.rb
@@ -59,7 +59,7 @@ multi-parent
   let(:source_path) { 'spec/fixtures/source' }
   let(:temp_doc) { File.join(source_path, 'components', 'button', 'skin', 'testSkin.css') }
 
-  subject(:parser) { Hologram::DocParser.new('spec/fixtures/source') }
+  subject(:parser) { Hologram::DocParser.new('spec/fixtures/source/components') }
 
   context '#parse' do
     let(:result) { parser.parse }
@@ -69,6 +69,15 @@ multi-parent
     it 'builds and returns a hash of pages and a hash of output_files_by_category' do
       expect(pages).to be_a Hash
       expect(output_files_by_category).to be_a Hash
+    end
+
+    context "when the source has multiple paths" do
+      subject(:parser) { Hologram::DocParser.new(['spec/fixtures/source/colors', 'spec/fixtures/source/components']) }
+
+      it "parses all sources" do
+        expect(pages['base_css.html'][:md]).to include 'Base colors'
+        expect(pages['base_css.html'][:md]).to include 'Background Colors'
+      end
     end
 
     context 'when the component has two categories' do

--- a/spec/fixtures/source/colors/colors.css
+++ b/spec/fixtures/source/colors/colors.css
@@ -1,0 +1,11 @@
+/*doc
+---
+title: Colors
+name: colors
+category: Base CSS
+---
+
+Base colors
+
+
+*/

--- a/spec/fixtures/source/config_multi_source.yml
+++ b/spec/fixtures/source/config_multi_source.yml
@@ -1,0 +1,19 @@
+# Hologram config
+
+# The directory containing the source files to parse
+source:
+  - ./components
+  - ./templates
+
+# The assets needed to build the docs (includes header.html, footer.html, etc)
+documentation_assets: ./templates
+
+# This is a custom markdown renderer (see Redcarpet documentation for
+# how to do this)
+# custom_markdown: trulia_markdown_renderer.rb
+
+# Any other asset folders that need to be copied to the destination folder
+# This where you should include your full stylesheets, component javascript,
+# libraries and any other dependencies your style guide will have
+dependencies:
+  - ./extra


### PR DESCRIPTION
- Source now allows either a single value (keeping backwards compatibility)
  or a yaml array of sources.
- This is useful when pulling in a library that comes with Hologram docs
  support built in.
- We considered auto resolving conflicting namespacing for multiple
  libraries, but we weren't sure that was really an essential feature.
  We'll use this feature for a bit, and add it if it seems worth the
  effort.
- We didn't modify the CLI to take multiple sources, if you'd like that
  feature, we're happy to add it.
