### PR TITLE
Display warning when multiple components have the same name.

### DIFF
--- a/lib/hologram/doc_block_collection.rb
+++ b/lib/hologram/doc_block_collection.rb
@@ -15,7 +15,11 @@ module Hologram
         return
       end
 
-      @doc_blocks[doc_block.name] = doc_block
+      if @doc_blocks.has_key?(doc_block.name)
+        DisplayMessage.warning("Multiple Hologram comments with name: #{doc_block.name}.")
+      else
+        @doc_blocks[doc_block.name] = doc_block
+      end
       return doc_block
     end
 

--- a/spec/doc_block_collection_spec.rb
+++ b/spec/doc_block_collection_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Hologram::DocBlockCollection do
   let(:comment) do
-   comment = <<comment
+    <<-comment
 /*doc
 ---
 title: Buttons
@@ -47,6 +47,31 @@ comment
 
       it 'does not add a new block' do
         expect(collection.doc_blocks.size).to eql 0
+      end
+    end
+
+    context 'when the block has the same name as another block in the collection' do
+      let(:duplicate_comment) do
+        <<-comment
+/*doc
+---
+title: Imposter Buttons
+name: button
+category: Base CSS
+---
+
+Same old stuff
+*/
+comment
+      end
+
+      before do
+        collection.add_doc_block(comment, 'fake_file.sass')
+      end
+
+      it 'displays a warning' do
+        expect(Hologram::DisplayMessage).to receive(:warning)
+        collection.add_doc_block(duplicate_comment, 'fake_file.sass')
       end
     end
   end


### PR DESCRIPTION
This fixes #7 
cc: @gpleiss 
