### PR TITLE
Add JSX support to BlockCodeRenderer

### DIFF
--- a/lib/hologram/block_code_renderer.rb
+++ b/lib/hologram/block_code_renderer.rb
@@ -27,6 +27,12 @@ module Hologram
           code_block(code, extra_classes: ['jsExample'])
         ].join('')
 
+      elsif is_jsx?
+        [
+          "<script type='text/jsx'>#{code}</script> ",
+          code_block(code, extra_classes: ['jsExample'])
+        ].join('')
+
       else
         code_block(code)
       end
@@ -44,6 +50,10 @@ module Hologram
 
     def is_js?
       markdown_language && markdown_language == 'js_example'
+    end
+
+    def is_jsx?
+      markdown_language && markdown_language == 'jsx_example'
     end
 
     def is_table?
@@ -112,6 +122,8 @@ module Hologram
         Rouge::Lexer.find('haml')
       elsif is_js?
         Rouge::Lexer.find('js')
+      elsif is_jsx?
+        Rouge::Lexer.find('html')
       else
         Rouge::Lexer.find_fancy('guess', code)
       end

--- a/spec/block_code_renderer_spec.rb
+++ b/spec/block_code_renderer_spec.rb
@@ -238,6 +238,36 @@ describe Hologram::BlockCodeRenderer do
           "</div>",
         ].join('') }
       end
+
+      context 'jsx_example' do
+        let(:language) { 'jsx' }
+        let(:markdown_language) { 'jsx_example' }
+        let(:code) { '$(document).ready(function () { React.render(<div className="foo"></div>) });' }
+        let(:formatted_code) { 'formatted document.ready' }
+
+        it 'creates the appropriate lexer' do
+          expect(Rouge::Lexer).to receive(:find).with('html')
+          subject
+        end
+
+        it "inserts the code into the docs so that it will run and make the example work" do
+          expect(subject).to include [
+            "<script type='text/jsx'>",
+              "$(document).ready(function () { React.render(<div className=\"foo\"></div>) });",
+            "</script> ",
+          ].join('')
+        end
+
+        it { is_expected.to include [
+          "<div class=\"codeBlock jsExample\">",
+            "<div class=\"highlight\">",
+              "<pre>",
+                "formatted document.ready",
+              "</pre>",
+            "</div>",
+          "</div>",
+        ].join('') }
+      end
     end
 
     context 'unexpected language' do


### PR DESCRIPTION
Uses HTML for syntax highlighting. Useful if you're using React components in your styleguide.

What do you think?

@stubbornella & @pmeskers

Signed-off-by: Nicole Sullivan nsullivan@pivotal.io
