### PR TITLE
Process sass in scss

### DIFF
--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -85,10 +85,17 @@ module Hologram
       # get any comment blocks that match the patterns:
       # .sass: //doc (follow by other lines proceeded by a space)
       # other types: /*doc ... */
-      if file.end_with?('.sass', '.scss')
-        hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/)
+      if file.end_with?('.sass')
+        #For sass strip out leading white spaces after we get the
+        #comment, this fixes haml when using this comment style
+        hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/).map{ |arr| [arr[0].gsub(/^[ \t]{2}/,'')] }
       else
         hologram_comments = file_str.scan(/^\s*\/\*doc(.*?)\*\//m)
+
+        #check if scss file has sass comments
+        if hologram_comments.length == 0 and file.end_with?('.scss')
+          hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/).map{ |arr| [arr[0].gsub(/^[ \t]{2}/,'')] }
+        end
       end
       return unless hologram_comments
 


### PR DESCRIPTION
There have been several requests to process sass comments in scss files. I think it's a good choice, but we cannot stop processing css comments in sass. This PR first tries to find css doc blocks and if that fails it will then try to find sass doc blocks when processing .scss files.

This isn't the cleanest way to do this but for now I'm trying to ease back into hologram maintenance and I think it'll be okay for a while.
