### PR TITLE
Fix nil.map call in link_helper

### DIFF
--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -185,10 +185,17 @@ module Hologram
 
     def link_helper
       @_link_helper ||= LinkHelper.new(@pages.map { |page|
+        if not page[1][:blocks].nil?
         {
           name: page[0],
           component_names: page[1][:blocks].map { |component| component[:name] }
         }
+        else
+        {
+          name: page[0],
+          component_names: {}
+        }
+        end
       })
     end
 


### PR DESCRIPTION
@gpleiss I'm seeing:

```
/home/jd/.gem/ruby/bundler/gems/hologram-bcd45252c628/lib/hologram/doc_builder.rb:190:
in `block in link_helper': undefined method `map' for nil:NilClass (NoMethodError)
```

When building our current style guide with the latest hologram master. Does this seem like an appropriate fix? I've not spent enough time working out why `:blocks` is empty in the spot, but it seems like for Trulia's use case it is happening.
