### PR TITLE
Remove preceding slash on reference links.

### DIFF
--- a/lib/hologram/link_helper.rb
+++ b/lib/hologram/link_helper.rb
@@ -4,7 +4,7 @@ module Hologram
       @all_links = {}
       pages.each do |page|
         page[:component_names].each do |component_name|
-          @all_links[component_name] ||= "/#{page[:name]}\##{component_name}"
+          @all_links[component_name] ||= "#{page[:name]}\##{component_name}"
         end
       end
     end

--- a/spec/fixtures/styleguide/base_css.html
+++ b/spec/fixtures/styleguide/base_css.html
@@ -175,7 +175,7 @@ size and style modifiers.</p><div class="codeTable">
 
 
 <h2 id="buttonSkins" class="styleguide">Button Styles</h2>
-<p class="styleguide">For buttons, see <a class="styleguide" href="/base_css.html#button" title="/base_css.html#button">the buttons docs</a>.</p><table class="styleguide"> <tr>
+<p class="styleguide">For buttons, see <a class="styleguide" href="base_css.html#button" title="base_css.html#button">the buttons docs</a>.</p><table class="styleguide"> <tr>
 <th>Button</th>
 <th>Class</th>
 <th>Description</th>

--- a/spec/link_helper_spec.rb
+++ b/spec/link_helper_spec.rb
@@ -33,13 +33,13 @@ describe Hologram::LinkHelper do
 
     context 'when the link belongs to only one page' do
       let(:component_name) { 'whitespace' }
-      it { should == '/utilities.html#whitespace' }
+      it { should == 'utilities.html#whitespace' }
     end
 
     context 'when the link belongs to more than one page' do
       let(:component_name) { 'typography' }
       it 'creates a link to the first page the component appears on' do
-        expect(subject).to eq '/elements.html#typography'
+        expect(subject).to eq 'elements.html#typography'
       end
     end
   end
@@ -47,10 +47,10 @@ describe Hologram::LinkHelper do
   describe '#all_links' do
     it 'returns a hash from component name to link' do
       expect(link_helper.all_links).to eq ({
-        'images' => '/elements.html#images',
-        'buttons' => '/elements.html#buttons',
-        'typography' => '/elements.html#typography',
-        'whitespace' => '/utilities.html#whitespace',
+        'images' => 'elements.html#images',
+        'buttons' => 'elements.html#buttons',
+        'typography' => 'elements.html#typography',
+        'whitespace' => 'utilities.html#whitespace',
       })
     end
   end

--- a/spec/markdown_renderer_spec.rb
+++ b/spec/markdown_renderer_spec.rb
@@ -28,9 +28,9 @@ describe Hologram::MarkdownRenderer do
 
       it 'prepends a list of component names and links to the document' do
         expect(subject).to eq [
-          "[link]: /elements.html#link",
-          "[typography]: /elements.html#typography",
-          "[alert]: /objects.html#alert",
+          "[link]: elements.html#link",
+          "[typography]: elements.html#typography",
+          "[alert]: objects.html#alert",
           "<p>i'm a <a href='#'>proper reference link</a></p>",
           "<p>i'm similar to an [invalid reference link] [but not quite]</p>",
         ].join("\n")


### PR DESCRIPTION
All reference links used to create an href with a preceding slash.
(i.e. "/elements.html#buttons"). This created a problem for people who
were using their styleguide on a file system. Removing the preceding
slash solves this. In addition, these links should still work for
people who have their styleguide on a server.

This addresses #191 