### PR TITLE
Add a React code renderer for boilerplate-free React examples.

### DIFF
--- a/lib/hologram/code_example_renderer/renderers/react_renderer.rb
+++ b/lib/hologram/code_example_renderer/renderers/react_renderer.rb
@@ -1,0 +1,21 @@
+require 'securerandom'
+
+Hologram::CodeExampleRenderer::Factory.define 'react' do
+  example_template 'markup_example_template'
+  table_template 'markup_table_template'
+
+  lexer { Rouge::Lexer.find(:html) }
+
+  rendered_example do |code|
+    div_id = SecureRandom.hex(10)
+    [
+      "<div id=\"#{div_id}\"></div>",
+      "<script type=\"text/jsx\">",
+      "  React.render(",
+      "    #{code.strip},",
+      "    document.getElementById('#{div_id}')",
+      "  );",
+      "</script>"
+    ].join("\n")
+  end
+end

--- a/spec/block_code_renderer_spec.rb
+++ b/spec/block_code_renderer_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'hologram/block_code_renderer'
 require 'haml'
+require 'securerandom'
 
 Hologram::CodeExampleRenderer.load_renderers_and_templates
 
@@ -9,6 +10,39 @@ describe Hologram::BlockCodeRenderer do
     subject { Hologram::BlockCodeRenderer.new(code, markdown_language).render.strip }
 
     context 'expected language' do
+      context 'react' do
+        let(:language) { 'react' }
+        let(:code) { '<ReactExample property="value">Example</ReactExample>' }
+
+        context 'when the language is a react_example' do
+          let(:markdown_language) { 'react_example' }
+          let(:div_id) { 'randomId' }
+
+          before :each do
+            SecureRandom.stub('hex').and_return(div_id);
+          end
+
+          it { is_expected.to eq [
+            "<div class=\"codeExample\">",
+            "  <div class=\"exampleOutput\">",
+            "    <div id=\"#{div_id}\"></div>",
+            "<script type=\"text/jsx\">",
+            "  React.render(",
+            "    <ReactExample property=\"value\">Example</ReactExample>,",
+            "    document.getElementById('#{div_id}')",
+            "  );",
+            "</script>",
+            "  </div>",
+            "  <div class=\"codeBlock\">",
+            "    <div class=\"highlight\">",
+            "      <pre><span class=\"nt\">&lt;ReactExample</span> <span class=\"na\">property=</span><span class=\"s\">\"value\"</span><span class=\"nt\">&gt;</span>Example<span class=\"nt\">&lt;/ReactExample&gt;</span></pre>",
+            "    </div>",
+            "  </div>",
+            "</div>"
+          ].join("\n") }
+        end
+      end
+
       context 'slim' do
         let(:language) { 'slim' }
         let(:code) { 'h1 Markup Example' }


### PR DESCRIPTION
This adds a basic renderer for React examples that removes the boilerplate of having to render a React component to a particular DOM element. 

![screen shot 2015-01-16 at 4 52 21 pm](https://cloud.githubusercontent.com/assets/693476/5785043/269433fc-9da0-11e4-91db-2903db6a66cc.png)

This was originally written by @gpleiss, I've just put a bow on it. 