### PR TITLE
change README documentation for having a custom index.md file, misleadin...

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Your config file needs to contain the following key/value pairs
       - ./build
 
     # Mark which category should be the index page
-    # Alternatively, you may have an index.md in the documentation assets
+    # Alternatively, you may have an index.md in the source directory root
     # folder instead of specifying this config.
     index: basics
 


### PR DESCRIPTION
...g with documentation assets

I know it's a minor change, but I couldn't figure out for a few hours how to setup a custom index page b/c I kept thinking documentation assets was somehow referring to the doc_assets folder. this change I think will help alleviate that. 

Thanks for all the great work on hologram. It's awesome!