### PR TITLE
Process YAML frontmatter in .md files

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,10 @@ following keys:
   component. If this is set, the current component will be displayed as
   a section within the **parent**'s documentation, but only if it specifies
   the same **category**, or allows the **category** to be inherited from its **parent**.
+* **hologram**: (markdown only) To avoid conflicts with Jekyll and
+  other YAML+markdown formats, Markdown (`.md`) files must include a
+  `hologram: true` key/value pair in the YAML block to indicate that
+  it is intended to be processed by Hologram.
 
 For example, you might have a component with the **name** *buttons* and
 another component named *buttonSkins*. You could set the **parent** for

--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -71,12 +71,22 @@ module Hologram
     def process_files(files, directory, doc_block_collection)
       files.each do |input_file|
         if input_file.end_with?('md')
-          @pages[File.basename(input_file, '.md') + '.html'] = {:md => File.read("#{directory}/#{input_file}"), :blocks => []}
+          process_markdown_file("#{directory}/#{input_file}", doc_block_collection)
         elsif input_file.end_with?('erb')
           @pages[File.basename(input_file, '.erb')] = {:erb => File.read("#{directory}/#{input_file}")}
         else
           process_file("#{directory}/#{input_file}", doc_block_collection)
         end
+      end
+    end
+
+    def process_markdown_file(file, doc_block_collection)
+      file_str = File.read(file)
+
+      if file_str.match(/^-{3}\n\w+:\s.*-{3}/m)
+        doc_block_collection.add_doc_block(file_str, file)
+      else
+        @pages[File.basename(file, '.md') + '.html'] = {:md => file_str, :blocks => []}
       end
     end
 

--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -83,7 +83,7 @@ module Hologram
     def process_markdown_file(file, doc_block_collection)
       file_str = File.read(file)
 
-      if file_str.match(/^-{3}\n\w+:\s.*-{3}/m)
+      if file_str.match(/^-{3}\n.*hologram:\s*true.*-{3}/m)
         doc_block_collection.add_doc_block(file_str, file)
       else
         @pages[File.basename(file, '.md') + '.html'] = {:md => file_str, :blocks => []}

--- a/spec/doc_builder_spec.rb
+++ b/spec/doc_builder_spec.rb
@@ -252,6 +252,7 @@ describe Hologram::DocBuilder do
       builder.build
       expect(File.read(File.expand_path('../fixtures/styleguide/base_css.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'base_css.html'))
       expect(File.read(File.expand_path('../fixtures/styleguide/index.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'index.html'))
+      expect(File.read(File.expand_path('../fixtures/styleguide/code.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'code.html'))
     end
   end
 end

--- a/spec/doc_builder_spec.rb
+++ b/spec/doc_builder_spec.rb
@@ -253,6 +253,7 @@ describe Hologram::DocBuilder do
       expect(File.read(File.expand_path('../fixtures/styleguide/base_css.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'base_css.html'))
       expect(File.read(File.expand_path('../fixtures/styleguide/index.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'index.html'))
       expect(File.read(File.expand_path('../fixtures/styleguide/code.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'code.html'))
+      expect(File.read(File.expand_path('../fixtures/styleguide/jekyll.html', __FILE__))).to eq File.read(File.join(builder.destination, '.', 'jekyll.html'))
     end
   end
 end

--- a/spec/doc_parser_spec.rb
+++ b/spec/doc_parser_spec.rb
@@ -120,7 +120,7 @@ multi-parent
       end
 
       it 'adds two categories to output_files_by_category' do
-        expect(output_files_by_category).to eql({'Foo'=>'foo.html', 'Base CSS'=>'base_css.html', 'Bar'=>'bar.html'})
+        expect(output_files_by_category).to eql({'Foo'=>'foo.html', 'Base CSS'=>'base_css.html', 'Bar'=>'bar.html', 'Code'=>'code.html'})
       end
     end
 

--- a/spec/fixtures/source/components/bem.md
+++ b/spec/fixtures/source/components/bem.md
@@ -1,0 +1,11 @@
+---
+title: BEM-like class naming
+name: bem
+category: Code
+---
+
+We use a BEM-like naming convention [similar to Harry Roberts'](http://cssguidelin.es/#bem-like-naming):
+
+    .block {}
+    .block__element {}
+    .block--modifier {}

--- a/spec/fixtures/source/components/bem.md
+++ b/spec/fixtures/source/components/bem.md
@@ -1,4 +1,5 @@
 ---
+hologram: true
 title: BEM-like class naming
 name: bem
 category: Code

--- a/spec/fixtures/source/components/jekyll.md
+++ b/spec/fixtures/source/components/jekyll.md
@@ -1,0 +1,7 @@
+---
+layout: post
+title: Blogging Like a Hacker
+---
+
+This is an example of a markdown file whose YAML frontmatter will
+be ignored by Hologram.

--- a/spec/fixtures/styleguide/code.html
+++ b/spec/fixtures/styleguide/code.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+
+    <title>My Style Guide Code</title>
+
+    <!-- Styleguide CSS -->
+    <link rel="stylesheet" href="static/css/doc.css">
+    <link rel="stylesheet" href="static/css/github.css">
+
+    <!-- CSS to be documented -->
+    <link rel="stylesheet" href="extra/css/screen.css">
+</head>
+
+  <body>
+    <header class="header pbn" role="banner">
+      <div class="backgroundHighlight typeReversed1">
+        <div class="container">
+          <h1 class="h2 mvs">My Style Guide</h1>
+        </div>
+      </div>
+      <div class="backgroundLowlight typeReversed1">
+        <div class="container">
+          <span>
+            <ul class="docNav listInline">
+              <!-- Add you pages here -->
+              <li><a href="index.html">Intro</a></li>
+              <li><a href="base_css.html">Base CSS</a></li>
+            </ul>
+          </span>
+        </div>
+      </div>
+      <!-- //header/container -->
+    </header>
+
+    <div class="content">
+      <section>
+        <div class="line">
+
+          <div class="col cols4">
+            <div class="componentMenu box boxBasic backgroundBasic">
+              <div class="boxBody pan">
+                <ul class="componentList listBorderedHover">
+                  
+                    <li><a href="#bem">BEM-like class naming</a></li>
+                  
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="main col cols20 lastCol">
+
+
+
+<h1 id="bem" class="styleguide">BEM-like class naming</h1>
+<p class="styleguide">We use a BEM-like naming convention <a class="styleguide" href="http://cssguidelin.es/#bem-like-naming" title="http://cssguidelin.es/#bem-like-naming">similar to Harry Roberts&#39;</a>:</p><div class="codeBlock">
+  <div class="highlight">
+    <pre>.block {}
+.block__element {}
+.block--modifier {}</pre>
+  </div>
+</div>      </div>
+    </div>
+  </section>
+  <footer>
+    The source code for this style guide is licensed under the MIT license.
+  </footer>
+</div>
+</body>
+</html>

--- a/spec/fixtures/styleguide/jekyll.html
+++ b/spec/fixtures/styleguide/jekyll.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+
+    <title>My Style Guide </title>
+
+    <!-- Styleguide CSS -->
+    <link rel="stylesheet" href="static/css/doc.css">
+    <link rel="stylesheet" href="static/css/github.css">
+
+    <!-- CSS to be documented -->
+    <link rel="stylesheet" href="extra/css/screen.css">
+</head>
+
+  <body>
+    <header class="header pbn" role="banner">
+      <div class="backgroundHighlight typeReversed1">
+        <div class="container">
+          <h1 class="h2 mvs">My Style Guide</h1>
+        </div>
+      </div>
+      <div class="backgroundLowlight typeReversed1">
+        <div class="container">
+          <span>
+            <ul class="docNav listInline">
+              <!-- Add you pages here -->
+              <li><a href="index.html">Intro</a></li>
+              <li><a href="base_css.html">Base CSS</a></li>
+            </ul>
+          </span>
+        </div>
+      </div>
+      <!-- //header/container -->
+    </header>
+
+    <div class="content">
+      <section>
+        <div class="line">
+
+          <div class="col cols4">
+            <div class="componentMenu box boxBasic backgroundBasic">
+              <div class="boxBody pan">
+                <ul class="componentList listBorderedHover">
+                  
+                </ul>
+              </div>
+            </div>
+          </div>
+
+          <div class="main col cols20 lastCol">
+
+
+
+<hr>
+<p class="styleguide">layout: post</p>
+<h2>title: Blogging Like a Hacker</h2>
+<p class="styleguide">This is an example of a markdown file whose YAML frontmatter will
+be ignored by Hologram.</p>      </div>
+    </div>
+  </section>
+  <footer>
+    The source code for this style guide is licensed under the MIT license.
+  </footer>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Allows markdown files to be treated as doc blocks if they open with YAML.

* [Example of a markdown file with YAML frontmatter](https://github.com/redoPop/hologram/blob/md-docblock/spec/fixtures/source/components/bem.md) – note that GitHub [has special support for rendering YAML frontmatter in markdown](https://github.com/blog/1647-viewing-yaml-metadata-in-your-documents).
* [Example of HTML output](https://github.com/redoPop/hologram/blob/md-docblock/spec/fixtures/styleguide/code.html) generated from the `bem.md` source in the previous example. (These files are used for for new tests.)
* Compatibility is maintained for markdown files that don't include YAML; e.g. [the `index.md` fixture](https://github.com/redoPop/hologram/blob/md-docblock/spec/fixtures/source/components/index.md). Plain markdown files are treated just as they were before.

Summary of change:

`process_files` now examines the contents of each `.md` file to see if its opening lines look like YAML. If so, the file's contents are added to the `doc_block_collection`.

Resolves #188 since title can be specified in the YAML configuration.

My own use case is producing a CSS _code_ style guide alongside the pattern style guide – i.e., documentation that doesn't really belong in a Sass/scss file. Using `.md` files for this documentation also makes them readable directly in GitHub, which is a nice bonus.