### PR TITLE
Optional config setting for including additional file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ Your config file needs to contain the following key/value pairs
   `all` sets it to show sub navigation for all sections. `all` can be a bit
   much, you'll probably want `section`.
 
+* **custom_extensions**: (optional) Additional file extensions that will be
+  included in the parse. Accepts both a single value and an array. The
+  current supported file extensions are `.css`, `.scss`, `.less`, `.sass`,
+  `.styl`, `.js`, `.md`, `.markdown` and `.erb`.
+
 * **exit_on_warnings**: (optional) Hologram displays warnings when there
   are issues with your docs (e.g. if a component's parent is not found,
   if the _header.html and/or _footer.html files aren't found)

--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -63,6 +63,7 @@ module Hologram
       @exit_on_warnings = options['exit_on_warnings']
       @code_example_templates = options['code_example_templates']
       @code_example_renderers = options['code_example_renderers']
+      @custom_extensions = Array(options['custom_extensions'])
 
       if @exit_on_warnings
         DisplayMessage.exit_on_warnings!
@@ -132,7 +133,8 @@ module Hologram
     end
 
     def build_docs
-      doc_parser = DocParser.new(input_dir, index, @plugins, nav_level: @nav_level)
+      doc_parser = DocParser.new(input_dir, index, @plugins, nav_level: @nav_level,
+                                                             custom_extensions: @custom_extensions)
       @pages, @categories = doc_parser.parse
 
       if index && !@pages.has_key?(index + '.html')

--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -1,6 +1,6 @@
 module Hologram
   class DocParser
-    SUPPORTED_EXTENSIONS = ['.css', '.scss', '.less', '.sass', '.styl', '.js', '.md', '.markdown', '.erb' ]
+    DEFAULT_SUPPORTED_EXTENSIONS = ['.css', '.scss', '.less', '.sass', '.styl', '.js', '.md', '.markdown', '.erb' ]
     attr_accessor :source_path, :pages, :doc_blocks, :nav_level
 
     def initialize(source_path, index_name = nil, plugins=[], opts={})
@@ -10,6 +10,8 @@ module Hologram
       @nav_level = opts[:nav_level] || 'page'
       @pages = {}
       @output_files_by_category = {}
+      @supported_extensions = DEFAULT_SUPPORTED_EXTENSIONS
+      @supported_extensions += opts[:custom_extensions] if opts[:custom_extensions]
     end
 
     def parse
@@ -129,7 +131,7 @@ module Hologram
     end
 
     def is_supported_file_type?(file)
-      SUPPORTED_EXTENSIONS.include?(File.extname(file)) and !Dir.exists?(file)
+      @supported_extensions.include?(File.extname(file)) and !Dir.exists?(file)
     end
 
     def get_file_name(str)


### PR DESCRIPTION
Adding functionality somewhat requested in #196.

We've been using Hologram and are pleased with how extensible it is. We've written a custom renderer that parses Ruby files, but DocParser's supported file extensions are hard-coded in a constant. So far we've been monkey patching `.rb` into the array to get by. These changes allow additional file extensions to be included in the parse through a config setting.

Summary of change:

Renamed `SUPPORTED_EXTENSIONS` to `DEFAULT_SUPPORTED_EXTENSIONS`. The array of supported extensions is built in DocParser's initialization.
