### PR TITLE
Builder not delete dir

### DIFF
--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -142,7 +142,7 @@ module Hologram
       warn_missing_doc_assets
       write_docs
       copy_dependencies
-      sets
+      copy_assets
     end
 
     def copy_assets

--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -142,7 +142,7 @@ module Hologram
       warn_missing_doc_assets
       write_docs
       copy_dependencies
-      copy_assets
+      sets
     end
 
     def copy_assets
@@ -151,7 +151,8 @@ module Hologram
         # ignore . and .. directories and files that start with
         # underscore
         next if item == '.' or item == '..' or item.start_with?('_')
-        FileUtils.rm "#{output_dir}/#{item}", :force => true
+        FileUtils.rm "#{output_dir}/#{item}", :force => true if File.file?("#{output_dir}/#{item}")
+        FileUtils.rm_rf "#{output_dir}/#{item}" if File.directory?("#{output_dir}/#{item}")
         FileUtils.cp_r "#{doc_assets_dir}/#{item}", "#{output_dir}/#{item}"
       end
     end


### PR DESCRIPTION
I have a bug that when I have subfolder inside `doc_assets` when I run `hologram` it copies the whole folder inside the destination folder. For example if I have 

```
./docs_assets/static/
```

My destination folder would be

```
./docs/static/static
```

