### PR TITLE
Fixing issue with copy_assets

### DIFF
--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -152,7 +152,7 @@ module Hologram
         # underscore
         next if item == '.' or item == '..' or item.start_with?('_')
         FileUtils.rm "#{output_dir}/#{item}", :force => true
-        FileUtils.cp_r "#{doc_assets_dir}/#{item}", "#{output_dir}/#{item}"
+        FileUtils.cp_r "#{doc_assets_dir}/#{item}/.", "#{output_dir}/#{item}"
       end
     end
 


### PR DESCRIPTION
This is similar to #206, but I think this properly fixes the core issue.

If you have a folder inside of your `documentation_assets` path it will copy the folder itself into the new folder. According to the [documentation](http://ruby-doc.org/stdlib-1.9.3/libdoc/fileutils/rdoc/FileUtils.html#method-c-cp_r) the `cp_r` method will:

> Copies src to dest. If src is a directory, this method copies all its contents recursively. If dest is a directory, copies src to dest/src.

I don't believe this is the intention of this method. Again, from the documentation:

```ruby
# If you want to copy all contents of a directory instead of the
# directory itself, c.f. src/x -> dest/x, src/y -> dest/y,
# use following code.
FileUtils.cp_r 'src/.', 'dest'     # cp_r('src', 'dest') makes src/dest,
                                   # but this doesn't.
```

That is what I've changed this method to do.