### PR TITLE
Allow template variables to be set as nil

### DIFF
--- a/lib/hologram/template_variables.rb
+++ b/lib/hologram/template_variables.rb
@@ -10,7 +10,7 @@ module Hologram
 
     def set_args(args)
       args.each do |k,v|
-        instance_variable_set("@#{k}", v) unless v.nil?
+        instance_variable_set("@#{k}", v)
       end
     end
 


### PR DESCRIPTION
This is needed so that erb files do not have :blocks set sometimes but
nil at other times. Without this change if an erb file is processed
before a documentation page, blocks will (and other related vars) will be
nil while after documentation pages are processed blocks will be set for
erbs. That was unintentional and this fixes it.