### PR TITLE
Make scss regex behave like sass

### DIFF
--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -102,7 +102,7 @@ module Hologram
         #comment, this fixes haml when using this comment style
         hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/).map{ |arr| [arr[0].gsub(/^[ \t]{2}/,'')] }
       else
-        hologram_comments = file_str.scan(/^\s*\/\*doc(.*?)\*\//m)
+        hologram_comments = file_str.scan(/\s*\/\*doc(.*?)\*\//m)
 
         #check if scss file has sass comments
         if hologram_comments.length == 0 and file.end_with?('.scss')


### PR DESCRIPTION
This makes these two regexes behave similarly and fixes a long standing windows issue: https://github.com/trulia/hologram/issues/122