### PR TITLE
Add correct title for category index pages

### DIFF
--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -46,6 +46,8 @@ module Hologram
         name = @index_name + '.html'
         if @pages.has_key?(name)
           @pages['index.html'] = @pages[name]
+          title, _ = @output_files_by_category.rassoc(name)
+          @output_files_by_category[title] = 'index.html'
         end
       end
 


### PR DESCRIPTION
This addresses: https://github.com/trulia/hologram/issues/190 which with the latest changes instead of getting the wrong title you get an empty title. Now you should get the correct title for the chosen category