### PR TITLE
Deep copy index page hash on parse

### DIFF
--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -46,7 +46,7 @@ module Hologram
       if @index_name
         name = @index_name + '.html'
         if @pages.has_key?(name)
-          @pages['index.html'] = @pages[name]
+          @pages['index.html'] = Marshal.load(Marshal.dump(@pages[name]))
           title, _ = @output_files_by_category.rassoc(name)
           @output_files_by_category[title] = 'index.html'
         end


### PR DESCRIPTION
This PR is the result of investigating a bug related to a custom markdown renderer with a preprocess method.

## Background
I noticed that my preprocess method (a `sub!` on `full_document`) defined in a custom markdown renderer class was being applied twice in the generated index.html.

After some debugging I noticed that in `write_docs`, when `markdown.render` was called on `page[:md]` for the page I specified as the index (`css.html`), the preprocess transform was also applied to `page["index.html"][:md]`.

I traced the issue back to line 49 in `doc_parser.rb`. `@pages['index.html']` is a shallow copy of the specified index page, so changes to one with affect the other.

## Solution
I propose setting `@pages['index.html']` with a deep copy of the specified page hash. This change would prevent similar custom renderer related issues. Alternatively I could resolve my issue by deep copying `full_document` and editing it in my markdown renderer methods - I'm not familiar with the common practices around writing Redcarpet renderers, this could in fact be the better way forward.