### PR TITLE
Badges from shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hologram
-[![Gem Version](https://badge.fury.io/rb/hologram.png)](https://rubygems.org/gems/hologram)
-[![Build Status](https://travis-ci.org/trulia/hologram.png)](https://travis-ci.org/trulia/hologram)
-[![Code Climate](https://codeclimate.com/github/trulia/hologram.png)](https://codeclimate.com/github/trulia/hologram)
-[![Dependency Status](https://gemnasium.com/trulia/hologram.png)](https://gemnasium.com/trulia/hologram)
+[![Gem Version](https://img.shields.io/gem/v/hologram.svg)](https://rubygems.org/gems/hologram)
+[![Build Status](https://img.shields.io/travis/trulia/hologram.svg)](https://travis-ci.org/trulia/hologram)
+[![Code Climate](https://img.shields.io/codeclimate/github/trulia/hologram.svg)](https://codeclimate.com/github/trulia/hologram)
+[![Dependency Status](https://img.shields.io/gemnasium/trulia/hologram.svg)](https://gemnasium.com/trulia/hologram)
 
 Hologram is a Ruby gem that parses comments in your CSS and helps you
 turn them into a beautiful style guide.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://img.shields.io/travis/trulia/hologram.svg)](https://travis-ci.org/trulia/hologram)
 [![Code Climate](https://img.shields.io/codeclimate/github/trulia/hologram.svg)](https://codeclimate.com/github/trulia/hologram)
 [![Dependency Status](https://img.shields.io/gemnasium/trulia/hologram.svg)](https://gemnasium.com/trulia/hologram)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.txt)
 
 Hologram is a Ruby gem that parses comments in your CSS and helps you
 turn them into a beautiful style guide.


### PR DESCRIPTION
Hi! This pull request uses badges from [shields.io](http://shields.io) for a consistent look-and-feel. There's another commit which adds a license badge, which can be optionally merged.