### PR TITLE
Add support for sass style comment in `.scss` files

### DIFF
--- a/lib/hologram/doc_parser.rb
+++ b/lib/hologram/doc_parser.rb
@@ -118,7 +118,7 @@ module Hologram
 
         #check if scss file has sass comments
         if hologram_comments.length == 0 and file.end_with?('.scss')
-          hologram_comments = file_str.scan(/\s*\/\/doc\s*((( [^\n]*\n)|\n)+)/).map{ |arr| [arr[0].gsub(/^[ \t]{2}/,'')] }
+          hologram_comments = file_str.scan(/\s*\/\/doc\s*((([\/ \t]{2}[^\n]*\n)|\n)+)/).map{ |arr| [arr[0].gsub(/[ \t]{2}/,'').gsub(/^\/\//, '')] }
         end
       end
       return unless hologram_comments

--- a/spec/doc_parser_spec.rb
+++ b/spec/doc_parser_spec.rb
@@ -82,8 +82,23 @@ multi-parent
     eos
   end
 
+  let(:scss_sass_doc) do
+    <<-eos
+//doc
+//  ---
+//  title: sass documentation
+//  name: sass_doc
+//  category: Foo
+//  ---
+//
+//  Some description
+//  on multiple lines
+    eos
+  end
+
   let(:source_path) { 'spec/fixtures/source' }
   let(:temp_doc) { File.join(source_path, 'components', 'button', 'skin', 'testSkin.css') }
+  let(:scss_temp_doc) { File.join(source_path, 'components', 'button', 'skin', 'scssComponents.scss') }
   let(:plugins) {
     plugins = double()
     allow(plugins).to receive(:block)
@@ -223,6 +238,18 @@ multi-parent
       it 'should correctly order content in each page' do
         objects = expect(pages['foo.html'][:md]).to match(/multi-parent.*multi-child/m)
         objects = expect(pages['bar.html'][:md]).to match(/multi-parent.*multi-child/m)
+      end
+    end
+
+    context 'when a scss file contains a sass documentation block' do
+      around do |example|
+        File.open(scss_temp_doc, 'w'){ |io| io << scss_sass_doc }
+        example.run
+        FileUtils.rm(scss_temp_doc)
+      end
+
+      it 'should parse the comment properly' do
+        objects = expect(pages['foo.html'][:md]).to include 'Some description'
       end
     end
   end


### PR DESCRIPTION
Comments should be in the form:
```
//doc
//  ---
//  title: something
//  category: ...
//  ---
//
```
Always have double space between the // and the content