### PR TITLE
Fix link to github.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ you probably want to include in your documentation assets folder is a
 css file that styles the "pygmentized" code examples. We use
 `github.css` which can be found along with the css we use to style code
 blocks
-[here](https://github.com/trulia/hologram-example/tree/gh-pages/hologram_assets/doc_assets/css).
+[here](https://github.com/trulia/hologram-example/tree/gh-pages/static/css).
 
 ### Custom Code Example Renderers
 


### PR DESCRIPTION
The link to the github.css file referenced in the docs is currently 404. This PR updates the link to what I assume to be the correct location.