### PR TITLE
Clean up "Build completed" message

### DIFF
--- a/lib/hologram/doc_builder.rb
+++ b/lib/hologram/doc_builder.rb
@@ -86,7 +86,7 @@ module Hologram
       # the real work happens here.
       build_docs
       Dir.chdir(current_path)
-      DisplayMessage.success("Build completed. (-: ")
+      DisplayMessage.success("Hologram build completed.")
       true
     end
 


### PR DESCRIPTION
Multiple members of my team were distracted by this emoticon, which is backwards from the traditional version (in this country anyway), :) — somehow it always looks like a :( frown as it slides by on the console.

Also took the opportunity to add "Hologram", since in our situation where you're scanning a lot of build output, it's helpful to be specific about what just finished.

- Remove distracting backwards emoticon
- Add “Hologram”, which is helpful messaging in a multiple-build situation