### PR TITLE
Break pre whitespace on landing page to wrap text instead of overflowing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -62,7 +62,8 @@ nav {
       text-align: left;
       margin: 1em auto;
       max-width: 500px;
-      word-wrap: break-word; }
+      word-wrap: break-word;
+      white-space: pre-line; }
     .container section h2 {
       margin-top: 2em; }
     .container section pre {

--- a/css/styles.sass
+++ b/css/styles.sass
@@ -87,6 +87,7 @@ nav
       margin: 1em auto
       max-width: 500px
       word-wrap: break-word
+      white-space: pre-line
 
     h2
       margin-top: 2em


### PR DESCRIPTION
This ensures the text inside of the `pre` section of the gh page is wrapped around. See the result:

<img width="584" alt="screen shot 2016-09-19 at 7 12 01 pm" src="https://cloud.githubusercontent.com/assets/437535/18655415/80fd4f6a-7e9d-11e6-994f-e2deb697da51.png">

Compared to previous:

<img width="862" alt="screen shot 2016-09-19 at 7 16 40 pm" src="https://cloud.githubusercontent.com/assets/437535/18655434/a4748602-7e9d-11e6-8a0d-2da1f7022f60.png">

I wasn't sure if I should `overflow-x: auto` or wrap line, but figured wrapping was a bit cleaner - overflowing didn't make it obvious that text was available past the scroll point. Also wasn't sure if I should be updating both styles.sass and styles.css or if there's a compile SASS > CSS step somewhere, so I covered both.
