### PR TITLE
Jsx renderer uses rouge jsx lexer (from 2.0.6 onwards)

### DIFF
--- a/hologram.gemspec
+++ b/hologram.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.add_dependency "redcarpet", ">= 2.2", "< 4.0"
-  spec.add_dependency "rouge", ">= 1.5", "!= 1.9.1"
+  spec.add_dependency "rouge", ">= 2.0.6"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = ['hologram']

--- a/lib/hologram/code_example_renderer/renderers/jsx_renderer.rb
+++ b/lib/hologram/code_example_renderer/renderers/jsx_renderer.rb
@@ -1,4 +1,4 @@
 Hologram::CodeExampleRenderer::Factory.define 'jsx' do
   example_template 'jsx_example_template'
-  lexer { Rouge::Lexer.find('html') }
+  lexer { Rouge::Lexer.find('jsx') }
 end


### PR DESCRIPTION
Signed-off-by: Tom Chen <tochen@pivotal.io>

See: https://github.com/jneen/rouge/issues/275